### PR TITLE
fix: squid, OAuth, skills, MCP, tmux improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ When full git support is enabled and the network firewall is active, SSH traffic
 
 ### External Tools
 
-External tools are third-party CLI tools (GitHub CLI, etc.) that can be selected during setup. Their required packages are automatically installed at image build time.
+External tools are third-party CLI tools (Bun, GitHub CLI, etc.) that can be selected during setup. Their required packages are automatically installed at image build time.
 
 ```bash
 # Configure via the setup wizard:
@@ -702,6 +702,7 @@ Profiles are pre-configured development environments. The setup wizard suggests 
 | `devops`      | Docker CLI / kubectl / helm / opentofu / kind |
 | `web`         | Web server/testing tools                 |
 | `security`    | Security diagnostics tools               |
+| `ml`          | AI/ML tooling (huggingface-cli, safetensors) — requires `python` |
 | `flutter`     | Flutter SDK                              |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ExitBox automatically:
 - **Named Resumable Sessions** — save and resume agent conversations by name across container restarts
 - **Multi-Agent Support** — run Claude Code, OpenAI Codex, or OpenCode in the same isolated environment
 - **Workspace Isolation** — named contexts (personal, work, client) with separate credentials, tools, and vault per workspace
+- **Codex Account Switching** — save and switch between multiple Codex logins inside a workspace with `exitbox codex accounts`
 - **IDE Integration** — Unix socket relay connects host editors (VS Code, Cursor, Windsurf) to agents inside the container for go-to-definition, diagnostics, and code actions
 - **Full Git Support** — optional mode that mounts host `.gitconfig` and SSH agent for seamless git operations inside the container
 - **GitHub CLI Authentication** — pre-flight vault import for `GITHUB_TOKEN` with automatic in-container export so `gh` and HTTPS git work transparently
@@ -166,6 +167,44 @@ exitbox run opencode -- auth logout   # remove stored credentials
 ```
 
 When the firewall is active, Google OAuth domains (`google.com`, `googleapis.com`) are included in the default allowlist. If you use a provider with a different OAuth domain, add it via `exitbox-allow <domain>` or the `-a` flag.
+
+### Codex Account Switching
+
+Codex CLI stores its login state in `.codex`, but ExitBox can keep multiple named Codex accounts per workspace and swap the active one without touching the rest of the workspace.
+
+```bash
+# Save the current login under a name
+exitbox codex accounts save personal
+
+# Create an empty slot for another login
+exitbox codex accounts add work
+
+# Log into that slot from your host shell
+# Do not type /login inside the Codex prompt
+exitbox run codex --workspace default -- login
+exitbox codex accounts save work
+
+# Switch back later
+exitbox codex accounts switch personal
+exitbox codex accounts list
+exitbox codex accounts current
+```
+
+How it works:
+
+- The active account for a workspace stays in that workspace's normal Codex config directory.
+- Saved accounts are stored as named sidecar copies under the same workspace profile.
+- `save <name>` snapshots the currently active Codex login.
+- `add <name>` creates a new empty active slot and clears the current Codex login so you can run `codex login`.
+- `switch <name>` saves the current active login back to its named slot, then restores the requested one.
+- `list` shows saved accounts and whether one is current, previous, or still pending login.
+- `current` shows the current and previous account names recorded for that workspace.
+
+Notes:
+
+- Account switching is workspace-local. `personal` in workspace `work` is separate from `personal` in workspace `default`.
+- Use `--workspace <name>` with any of these commands to manage accounts for a non-active workspace.
+- If the current Codex login has never been named, `add` or `switch` will ask you to save it first with `exitbox codex accounts save <name>`.
 
 ### RTK Token Optimizer (Experimental)
 
@@ -418,6 +457,11 @@ exitbox update            # Update ExitBox to the latest version
 exitbox aliases           # Print shell aliases for ~/.bashrc
 exitbox agents list       # List enabled agents and their status
 exitbox agents config <agent>  # Open agent config in $EDITOR
+exitbox codex accounts list     # List saved Codex accounts
+exitbox codex accounts current  # Show current/previous Codex account
+exitbox codex accounts save <name>   # Save active Codex login
+exitbox codex accounts add <name>    # Create a new empty Codex login slot
+exitbox codex accounts switch <name> # Activate a saved Codex login
 exitbox config import <agent|all>  # Import agent config from host
 exitbox config edit <agent>        # Open agent config file in $EDITOR
 exitbox skills install <source>    # Install a skill from URL/path

--- a/cmd/codex.go
+++ b/cmd/codex.go
@@ -1,0 +1,191 @@
+// ExitBox - Multi-Agent Container Sandbox
+// Copyright (C) 2026 Cloud Exit B.V.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloud-exit/exitbox/internal/agents/codex"
+	"github.com/cloud-exit/exitbox/internal/config"
+	"github.com/cloud-exit/exitbox/internal/profile"
+	"github.com/cloud-exit/exitbox/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newCodexCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "codex",
+		Short: "Manage Codex-specific features",
+	}
+	cmd.AddCommand(newCodexAccountsCmd())
+	return cmd
+}
+
+func newCodexAccountsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "accounts",
+		Short: "Manage multiple Codex logins inside a workspace",
+		Long: `Store, add, and switch named Codex accounts inside the active workspace.
+
+The active Codex login remains in the workspace's normal .codex config path.
+Saved accounts are stored in sidecar slots under the same workspace profile.`,
+	}
+
+	cmd.AddCommand(newCodexAccountsListCmd())
+	cmd.AddCommand(newCodexAccountsCurrentCmd())
+	cmd.AddCommand(newCodexAccountsSaveCmd())
+	cmd.AddCommand(newCodexAccountsAddCmd())
+	cmd.AddCommand(newCodexAccountsSwitchCmd())
+	return cmd
+}
+
+func newCodexAccountsListCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List saved Codex accounts for a workspace",
+		Run: func(cmd *cobra.Command, args []string) {
+			ws, manager := resolveCodexAccountManager(workspace)
+			items, err := manager.List()
+			if err != nil {
+				ui.Errorf("Failed to list Codex accounts: %v", err)
+			}
+
+			fmt.Printf("Workspace: %s\n", ws)
+			if len(items) == 0 {
+				fmt.Println("(no Codex accounts saved yet)")
+				return
+			}
+			for _, item := range items {
+				flags := make([]string, 0, 3)
+				if item.Current {
+					flags = append(flags, "current")
+				}
+				if item.Previous {
+					flags = append(flags, "previous")
+				}
+				if !item.Ready {
+					flags = append(flags, "pending-login")
+				}
+				if len(flags) == 0 {
+					fmt.Printf("  %s\n", item.Name)
+					continue
+				}
+				fmt.Printf("  %s (%s)\n", item.Name, strings.Join(flags, ", "))
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (default: active workspace)")
+	return cmd
+}
+
+func newCodexAccountsCurrentCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "current",
+		Short: "Show the current and previous Codex account names",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			ws, manager := resolveCodexAccountManager(workspace)
+			state, err := manager.LoadState()
+			if err != nil {
+				ui.Errorf("Failed to read Codex account state: %v", err)
+			}
+			fmt.Printf("Workspace: %s\n", ws)
+			if state.Current != "" {
+				fmt.Printf("Current: %s\n", state.Current)
+			} else {
+				fmt.Println("Current: (unknown)")
+			}
+			if state.Previous != "" {
+				fmt.Printf("Previous: %s\n", state.Previous)
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (default: active workspace)")
+	return cmd
+}
+
+func newCodexAccountsSaveCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "save <name>",
+		Short: "Save the active Codex login under a name",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ws, manager := resolveCodexAccountManager(workspace)
+			if err := manager.Save(args[0]); err != nil {
+				ui.Errorf("Failed to save Codex account in workspace '%s': %v", ws, err)
+			}
+			ui.Successf("Saved active Codex login as '%s' in workspace '%s'", args[0], ws)
+		},
+	}
+	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (default: active workspace)")
+	return cmd
+}
+
+func newCodexAccountsAddCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Create an empty Codex account slot and make it current",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ws, manager := resolveCodexAccountManager(workspace)
+			if err := manager.Add(args[0]); err != nil {
+				ui.Errorf("Failed to add Codex account in workspace '%s': %v", ws, err)
+			}
+			ui.Successf("Added Codex account '%s' in workspace '%s'", args[0], ws)
+			fmt.Printf("Next: exitbox run codex --workspace %s -- login\n", ws)
+			fmt.Println("Run that from your host shell, not from inside the Codex prompt.")
+			fmt.Printf("Optional: exitbox codex accounts save %s --workspace %s\n", args[0], ws)
+		},
+	}
+	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (default: active workspace)")
+	return cmd
+}
+
+func newCodexAccountsSwitchCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "switch <name>",
+		Short: "Switch the workspace's active Codex login",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ws, manager := resolveCodexAccountManager(workspace)
+			if err := manager.Switch(args[0]); err != nil {
+				ui.Errorf("Failed to switch Codex account in workspace '%s': %v", ws, err)
+			}
+			ui.Successf("Switched Codex account to '%s' in workspace '%s'", args[0], ws)
+		},
+	}
+	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (default: active workspace)")
+	return cmd
+}
+
+func resolveCodexAccountManager(workspace string) (string, *codex.AccountManager) {
+	cfg := config.LoadOrDefault()
+	ws := resolveConfigWorkspace(cfg, workspace)
+	root := profile.WorkspaceAgentDir(ws, "codex")
+	return ws, codex.NewAccountManager(root)
+}
+
+func init() {
+	rootCmd.AddCommand(newCodexCmd())
+}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cloud-exit/exitbox/internal/agents"
+	"github.com/cloud-exit/exitbox/internal/plugins"
+	"github.com/cloud-exit/exitbox/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newPluginCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage agent plugins",
+		Long:  "Clone, list, and remove workspace-scoped plugins for supported agents.",
+	}
+
+	cmd.AddCommand(newPluginInstallCmd())
+	cmd.AddCommand(newPluginListCmd())
+	cmd.AddCommand(newPluginRemoveCmd())
+	return cmd
+}
+
+func newPluginInstallCmd() *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "install <agent> <git-url-or-path>",
+		Short: "Install a plugin by cloning its repository",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			agentName := args[0]
+			source := args[1]
+
+			if agents.Get(agentName) == nil {
+				ui.Errorf("Unknown agent: %s", agentName)
+			}
+
+			projectDir, err := os.Getwd()
+			if err != nil {
+				ui.Errorf("Failed to determine current directory: %v", err)
+			}
+			installed, err := plugins.Install(projectDir, agentName, source, name)
+			if err != nil {
+				ui.Errorf("Failed to install plugin: %v", err)
+			}
+			if len(installed) == 1 {
+				ui.Successf("Installed plugin '%s' for %s in project '%s'", installed[0].Name, agentName, projectDir)
+				fmt.Printf("Host path: %s\n", installed[0].Dir)
+				return
+			}
+			ui.Successf("Installed %d plugins for %s in project '%s'", len(installed), agentName, projectDir)
+			for _, plugin := range installed {
+				fmt.Printf("%s -> %s\n", plugin.Name, plugin.Dir)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Override plugin directory name")
+	return cmd
+}
+
+func newPluginListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <agent>",
+		Short: "List installed plugins for an agent",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			agentName := args[0]
+			if agents.Get(agentName) == nil {
+				ui.Errorf("Unknown agent: %s", agentName)
+			}
+
+			projectDir, err := os.Getwd()
+			if err != nil {
+				ui.Errorf("Failed to determine current directory: %v", err)
+			}
+			list, err := plugins.List(projectDir, agentName)
+			if err != nil {
+				ui.Errorf("Failed to list plugins: %v", err)
+			}
+			if len(list) == 0 {
+				fmt.Println("(no plugins installed)")
+				return
+			}
+			for _, plugin := range list {
+				fmt.Println(plugin.Name)
+			}
+		},
+	}
+	return cmd
+}
+
+func newPluginRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <agent> <name>",
+		Short: "Remove an installed plugin",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			agentName := args[0]
+			name := args[1]
+
+			if agents.Get(agentName) == nil {
+				ui.Errorf("Unknown agent: %s", agentName)
+			}
+
+			projectDir, err := os.Getwd()
+			if err != nil {
+				ui.Errorf("Failed to determine current directory: %v", err)
+			}
+			if err := plugins.Remove(projectDir, agentName, name); err != nil {
+				ui.Errorf("Failed to remove plugin: %v", err)
+			}
+			ui.Successf("Removed plugin '%s' for %s from project '%s'", name, agentName, projectDir)
+		},
+	}
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newPluginCmd())
+}

--- a/internal/agents/claude/claude.go
+++ b/internal/agents/claude/claude.go
@@ -85,6 +85,9 @@ func (c *Claude) EnsureWorkspaceAgentConfig(workspaceName string) error {
 
 	cfgDir := fsutil.EnsureDir(root, ".config")
 	fsutil.SeedDirOnce(filepath.Join(home, ".config"), cfgDir)
+
+	// Persist ~/.cache so MCP OAuth tokens survive across sessions.
+	_ = fsutil.EnsureDir(root, ".cache")
 	return nil
 }
 

--- a/internal/agents/codex/accounts.go
+++ b/internal/agents/codex/accounts.go
@@ -1,0 +1,318 @@
+// ExitBox - Multi-Agent Container Sandbox
+// Copyright (C) 2026 Cloud Exit B.V.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cloud-exit/exitbox/internal/fsutil"
+)
+
+var (
+	ErrNoActiveAccountData  = errors.New("no active Codex account data found")
+	ErrUnnamedActiveAccount = errors.New("current Codex account is unnamed; run 'exitbox codex accounts save <name>' first")
+)
+
+type AccountState struct {
+	Current  string `json:"current,omitempty"`
+	Previous string `json:"previous,omitempty"`
+}
+
+type AccountInfo struct {
+	Name     string
+	Current  bool
+	Previous bool
+	Ready    bool
+}
+
+type AccountManager struct {
+	Root string
+}
+
+func NewAccountManager(root string) *AccountManager {
+	return &AccountManager{Root: root}
+}
+
+func (m *AccountManager) List() ([]AccountInfo, error) {
+	state, err := m.LoadState()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(m.accountsRoot())
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	items := make([]AccountInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		items = append(items, AccountInfo{
+			Name:     name,
+			Current:  name == state.Current,
+			Previous: name == state.Previous,
+			Ready:    m.accountHasData(name),
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+	})
+
+	return items, nil
+}
+
+func (m *AccountManager) LoadState() (AccountState, error) {
+	data, err := os.ReadFile(m.stateFile())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AccountState{}, nil
+		}
+		return AccountState{}, err
+	}
+
+	var state AccountState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return AccountState{}, err
+	}
+	return state, nil
+}
+
+func (m *AccountManager) Save(name string) error {
+	if err := validateAccountName(name); err != nil {
+		return err
+	}
+	if !m.ActiveDataExists() {
+		return ErrNoActiveAccountData
+	}
+	if err := m.copyActiveToAccount(name); err != nil {
+		return err
+	}
+
+	state, err := m.LoadState()
+	if err != nil {
+		return err
+	}
+	if state.Current != name {
+		state.Previous = state.Current
+	}
+	state.Current = name
+	return m.saveState(state)
+}
+
+func (m *AccountManager) Add(name string) error {
+	if err := validateAccountName(name); err != nil {
+		return err
+	}
+	if m.accountExists(name) {
+		return fmt.Errorf("Codex account %q already exists", name)
+	}
+
+	state, err := m.LoadState()
+	if err != nil {
+		return err
+	}
+	if m.ActiveDataExists() {
+		if state.Current == "" {
+			return ErrUnnamedActiveAccount
+		}
+		if err := m.copyActiveToAccount(state.Current); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(m.accountDir(name), 0755); err != nil {
+		return err
+	}
+	if err := m.clearActive(); err != nil {
+		return err
+	}
+
+	state.Previous = state.Current
+	state.Current = name
+	return m.saveState(state)
+}
+
+func (m *AccountManager) Switch(name string) error {
+	if err := validateAccountName(name); err != nil {
+		return err
+	}
+
+	state, err := m.LoadState()
+	if err != nil {
+		return err
+	}
+	if state.Current == name {
+		return nil
+	}
+	if !m.accountHasData(name) {
+		return fmt.Errorf("Codex account %q has no saved login yet", name)
+	}
+
+	if m.ActiveDataExists() {
+		if state.Current == "" {
+			return ErrUnnamedActiveAccount
+		}
+		if err := m.copyActiveToAccount(state.Current); err != nil {
+			return err
+		}
+	}
+
+	if err := m.clearActive(); err != nil {
+		return err
+	}
+	if err := m.copyAccountToActive(name); err != nil {
+		return err
+	}
+
+	state.Previous = state.Current
+	state.Current = name
+	return m.saveState(state)
+}
+
+func (m *AccountManager) ActiveDataExists() bool {
+	return dirHasEntries(m.activeCodexDir()) || dirHasEntries(m.activeConfigDir())
+}
+
+func (m *AccountManager) accountExists(name string) bool {
+	info, err := os.Stat(m.accountDir(name))
+	return err == nil && info.IsDir()
+}
+
+func (m *AccountManager) accountHasData(name string) bool {
+	return dirHasEntries(filepath.Join(m.accountDir(name), ".codex")) ||
+		dirHasEntries(filepath.Join(m.accountDir(name), ".config", "codex"))
+}
+
+func (m *AccountManager) copyActiveToAccount(name string) error {
+	if !m.ActiveDataExists() {
+		return ErrNoActiveAccountData
+	}
+
+	root := m.accountDir(name)
+	if err := os.RemoveAll(root); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return err
+	}
+	if err := copyIfPresent(m.activeCodexDir(), filepath.Join(root, ".codex")); err != nil {
+		return err
+	}
+	if err := copyIfPresent(m.activeConfigDir(), filepath.Join(root, ".config", "codex")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *AccountManager) copyAccountToActive(name string) error {
+	root := m.accountDir(name)
+	if err := copyIfPresent(filepath.Join(root, ".codex"), m.activeCodexDir()); err != nil {
+		return err
+	}
+	if err := copyIfPresent(filepath.Join(root, ".config", "codex"), m.activeConfigDir()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *AccountManager) clearActive() error {
+	if err := os.RemoveAll(m.activeCodexDir()); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(m.activeConfigDir()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *AccountManager) saveState(state AccountState) error {
+	if err := os.MkdirAll(filepath.Dir(m.stateFile()), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(m.stateFile(), data, 0644)
+}
+
+func (m *AccountManager) accountsRoot() string {
+	return filepath.Join(m.Root, ".exitbox", "accounts")
+}
+
+func (m *AccountManager) accountDir(name string) string {
+	return filepath.Join(m.accountsRoot(), name)
+}
+
+func (m *AccountManager) stateFile() string {
+	return filepath.Join(m.accountsRoot(), "state.json")
+}
+
+func (m *AccountManager) activeCodexDir() string {
+	return filepath.Join(m.Root, ".codex")
+}
+
+func (m *AccountManager) activeConfigDir() string {
+	return filepath.Join(m.Root, ".config", "codex")
+}
+
+func validateAccountName(name string) error {
+	name = strings.TrimSpace(name)
+	switch {
+	case name == "":
+		return errors.New("Codex account name cannot be empty")
+	case name == "." || name == "..":
+		return fmt.Errorf("invalid Codex account name %q", name)
+	case strings.ContainsAny(name, `/\`):
+		return fmt.Errorf("Codex account name %q cannot contain path separators", name)
+	default:
+		return nil
+	}
+}
+
+func copyIfPresent(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", src)
+	}
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+	return fsutil.CopyDirRecursive(src, dst)
+}
+
+func dirHasEntries(path string) bool {
+	entries, err := os.ReadDir(path)
+	return err == nil && len(entries) > 0
+}

--- a/internal/agents/codex/accounts_test.go
+++ b/internal/agents/codex/accounts_test.go
@@ -1,0 +1,178 @@
+// ExitBox - Multi-Agent Container Sandbox
+// Copyright (C) 2026 Cloud Exit B.V.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAccountManagerSaveAndSwitch(t *testing.T) {
+	root := t.TempDir()
+	manager := NewAccountManager(root)
+
+	writeAccountFixture(t, filepath.Join(root, ".codex"), "auth.json", "personal-auth")
+	writeAccountFixture(t, filepath.Join(root, ".config", "codex"), "config.json", "personal-config")
+
+	if err := manager.Save("personal"); err != nil {
+		t.Fatalf("Save(personal) error: %v", err)
+	}
+
+	state, err := manager.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState() error: %v", err)
+	}
+	if state.Current != "personal" {
+		t.Fatalf("Current = %q, want personal", state.Current)
+	}
+
+	writeAccountFixture(t, filepath.Join(root, ".codex"), "auth.json", "work-auth")
+	writeAccountFixture(t, filepath.Join(root, ".config", "codex"), "config.json", "work-config")
+
+	if err := manager.Save("work"); err != nil {
+		t.Fatalf("Save(work) error: %v", err)
+	}
+	if err := manager.Switch("personal"); err != nil {
+		t.Fatalf("Switch(personal) error: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(root, ".codex", "auth.json"), "personal-auth")
+	assertFileContent(t, filepath.Join(root, ".config", "codex", "config.json"), "personal-config")
+	assertFileContent(t, filepath.Join(root, ".exitbox", "accounts", "work", ".codex", "auth.json"), "work-auth")
+
+	state, err = manager.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState() after switch error: %v", err)
+	}
+	if state.Current != "personal" {
+		t.Fatalf("Current after switch = %q, want personal", state.Current)
+	}
+	if state.Previous != "work" {
+		t.Fatalf("Previous after switch = %q, want work", state.Previous)
+	}
+}
+
+func TestAccountManagerAddClearsActiveConfig(t *testing.T) {
+	root := t.TempDir()
+	manager := NewAccountManager(root)
+
+	writeAccountFixture(t, filepath.Join(root, ".codex"), "auth.json", "personal-auth")
+	if err := manager.Save("personal"); err != nil {
+		t.Fatalf("Save(personal) error: %v", err)
+	}
+
+	writeAccountFixture(t, filepath.Join(root, ".codex"), "auth.json", "transient-auth")
+	if err := manager.Add("work"); err != nil {
+		t.Fatalf("Add(work) error: %v", err)
+	}
+
+	if manager.ActiveDataExists() {
+		t.Fatal("Add(work) should clear the active Codex config")
+	}
+
+	state, err := manager.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState() error: %v", err)
+	}
+	if state.Current != "work" {
+		t.Fatalf("Current = %q, want work", state.Current)
+	}
+	if state.Previous != "personal" {
+		t.Fatalf("Previous = %q, want personal", state.Previous)
+	}
+
+	accounts, err := manager.List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("List() returned %d accounts, want 2", len(accounts))
+	}
+
+	var foundWork bool
+	for _, account := range accounts {
+		if account.Name == "work" {
+			foundWork = true
+			if account.Ready {
+				t.Fatal("newly added account should be pending login")
+			}
+		}
+	}
+	if !foundWork {
+		t.Fatal("expected to find work account")
+	}
+}
+
+func TestAccountManagerSwitchRequiresNamedCurrentAccount(t *testing.T) {
+	root := t.TempDir()
+	manager := NewAccountManager(root)
+
+	writeAccountFixture(t, filepath.Join(root, ".codex"), "auth.json", "unnamed-auth")
+	writeAccountFixture(t, filepath.Join(root, ".exitbox", "accounts", "personal", ".codex"), "auth.json", "personal-auth")
+
+	err := manager.Switch("personal")
+	if !errors.Is(err, ErrUnnamedActiveAccount) {
+		t.Fatalf("Switch(personal) error = %v, want %v", err, ErrUnnamedActiveAccount)
+	}
+}
+
+func TestValidateAccountName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "personal"},
+		{name: "work-2"},
+		{name: "", wantErr: true},
+		{name: ".", wantErr: true},
+		{name: "foo/bar", wantErr: true},
+		{name: `foo\bar`, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		err := validateAccountName(tc.name)
+		if tc.wantErr && err == nil {
+			t.Fatalf("validateAccountName(%q) expected error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("validateAccountName(%q) unexpected error: %v", tc.name, err)
+		}
+	}
+}
+
+func writeAccountFixture(t *testing.T, dir, name, value string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", filepath.Join(dir, name), err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s = %q, want %q", path, string(data), want)
+	}
+}

--- a/internal/agents/codex/codex_test.go
+++ b/internal/agents/codex/codex_test.go
@@ -70,6 +70,9 @@ func TestCodexAgent(t *testing.T) {
 	if !strings.Contains(df, "sha256sum") {
 		t.Error("GetDockerfileInstall() should contain sha256sum verification")
 	}
+	if !strings.Contains(df, "apk add --no-cache bubblewrap") {
+		t.Error("GetDockerfileInstall() should install bubblewrap")
+	}
 
 	// GetFullDockerfile
 	full, err := c.GetFullDockerfile("v0.1.0")

--- a/internal/agents/codex/docker.go
+++ b/internal/agents/codex/docker.go
@@ -32,7 +32,8 @@ func (c *Codex) GetDockerfileInstall(buildCtx string) (string, error) {
 	}
 	binaryInside := strings.TrimSuffix(binaryName, ".tar.gz")
 
-	return fmt.Sprintf(`# Install Codex binary with SHA-256 verification
+	return fmt.Sprintf(`# Install Codex runtime dependencies and binary with SHA-256 verification
+RUN apk add --no-cache bubblewrap
 ARG CODEX_VERSION
 ARG CODEX_CHECKSUM
 COPY %s /tmp/codex.tar.gz

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -183,6 +183,19 @@ func TestToolsHash_IncludesBinaries(t *testing.T) {
 	}
 }
 
+func TestToolsHash_IncludesExternalTools(t *testing.T) {
+	cfg1 := &config.Config{}
+	cfg2 := &config.Config{
+		ExternalTools: []string{"Bun"},
+	}
+
+	h1 := ToolsHash(cfg1)
+	h2 := ToolsHash(cfg2)
+	if h1 == h2 {
+		t.Error("ToolsHash should differ when external tools are added")
+	}
+}
+
 func TestWorkspaceHash_Deterministic(t *testing.T) {
 	cfg := config.DefaultConfig()
 	dir := t.TempDir()

--- a/internal/image/tools.go
+++ b/internal/image/tools.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloud-exit/exitbox/internal/config"
 	"github.com/cloud-exit/exitbox/internal/container"
 	"github.com/cloud-exit/exitbox/internal/ui"
+	"github.com/cloud-exit/exitbox/internal/wizard"
 )
 
 // ToolsHash computes a short hash of the global tool configuration
@@ -38,6 +39,7 @@ func ToolsHash(cfg *config.Config) string {
 	for _, b := range cfg.Tools.Binaries {
 		parts = append(parts, b.Name+"="+b.URLPattern)
 	}
+	parts = append(parts, cfg.ExternalTools...)
 	h := sha256.Sum256([]byte(strings.Join(parts, ",")))
 	return fmt.Sprintf("%x", h[:8])
 }
@@ -101,6 +103,14 @@ func BuildTools(ctx context.Context, rt container.Runtime, agentName string, for
 		url := strings.ReplaceAll(b.URLPattern, "{arch}", "${ARCH}")
 		df.WriteString(fmt.Sprintf("    curl -sL \"%s\" -o /usr/local/bin/%s && \\\n", url, b.Name))
 		df.WriteString(fmt.Sprintf("    chmod +x /usr/local/bin/%s\n\n", b.Name))
+	}
+
+	for _, step := range wizard.ComputeExternalToolInstallSteps(cfg.ExternalTools) {
+		df.WriteString(step)
+		if !strings.HasSuffix(step, "\n") {
+			df.WriteString("\n")
+		}
+		df.WriteString("\n")
 	}
 
 	// Stay as root — project layer handles USER switch

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -1,0 +1,283 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/cloud-exit/exitbox/internal/fsutil"
+)
+
+type Plugin struct {
+	Name string
+	Dir  string
+}
+
+type marketplace struct {
+	Name      string            `json:"name"`
+	Interface marketplaceUI     `json:"interface"`
+	Plugins   []marketplaceItem `json:"plugins"`
+}
+
+type marketplaceUI struct {
+	DisplayName string `json:"displayName"`
+}
+
+type marketplaceItem struct {
+	Name     string            `json:"name"`
+	Source   marketplaceSource `json:"source"`
+	Policy   marketplacePolicy `json:"policy"`
+	Category string            `json:"category"`
+}
+
+type marketplaceSource struct {
+	Source string `json:"source"`
+	Path   string `json:"path"`
+}
+
+type marketplacePolicy struct {
+	Installation   string `json:"installation"`
+	Authentication string `json:"authentication"`
+}
+
+// ProjectPluginsDir returns the plugin root for an agent in the current project.
+func ProjectPluginsDir(projectDir, agentName string) (string, error) {
+	switch agentName {
+	case "codex":
+		return filepath.Join(projectDir, "plugins"), nil
+	default:
+		return "", fmt.Errorf("agent %q does not support plugins", agentName)
+	}
+}
+
+func projectMarketplaceFile(projectDir, agentName string) (string, error) {
+	switch agentName {
+	case "codex":
+		return filepath.Join(projectDir, ".agents", "plugins", "marketplace.json"), nil
+	default:
+		return "", fmt.Errorf("agent %q does not support plugins", agentName)
+	}
+}
+
+// List returns installed plugin repositories for an agent in the current project.
+func List(projectDir, agentName string) ([]Plugin, error) {
+	root, err := ProjectPluginsDir(projectDir, agentName)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var result []Plugin
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		result = append(result, Plugin{
+			Name: entry.Name(),
+			Dir:  filepath.Join(root, entry.Name()),
+		})
+	}
+	return result, nil
+}
+
+// Install imports a Codex marketplace repo into the current project by copying
+// its referenced local plugins into ./plugins and merging marketplace entries
+// into ./.agents/plugins/marketplace.json.
+func Install(projectDir, agentName, source, name string) ([]Plugin, error) {
+	if _, err := ProjectPluginsDir(projectDir, agentName); err != nil {
+		return nil, err
+	}
+	if name != "" {
+		if err := validatePluginName(name); err != nil {
+			return nil, err
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp("", "exitbox-plugin-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cloneDir := filepath.Join(tmpDir, "repo")
+	cmd := exec.Command("git", "clone", "--depth", "1", "--recurse-submodules", source, cloneDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return nil, fmt.Errorf("git clone failed: %s", msg)
+		}
+		return nil, fmt.Errorf("git clone failed: %w", err)
+	}
+
+	repoMarketplacePath, err := projectMarketplaceFile(cloneDir, agentName)
+	if err != nil {
+		return nil, err
+	}
+	repoMarketplace, err := loadMarketplace(repoMarketplacePath)
+	if err != nil {
+		return nil, err
+	}
+	if len(repoMarketplace.Plugins) == 0 {
+		return nil, fmt.Errorf("no plugins found in marketplace %s", repoMarketplacePath)
+	}
+
+	projectPluginsDir, _ := ProjectPluginsDir(projectDir, agentName)
+	if err := os.MkdirAll(projectPluginsDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating plugin root: %w", err)
+	}
+
+	var installed []Plugin
+	var importedEntries []marketplaceItem
+	for _, entry := range repoMarketplace.Plugins {
+		if name != "" && entry.Name != name {
+			continue
+		}
+		if entry.Source.Source != "local" {
+			continue
+		}
+		if err := validatePluginName(entry.Name); err != nil {
+			return nil, err
+		}
+		srcPath := filepath.Join(cloneDir, filepath.Clean(entry.Source.Path))
+		destPath := filepath.Join(projectPluginsDir, entry.Name)
+		if _, err := os.Stat(destPath); err == nil {
+			return nil, fmt.Errorf("plugin %q already exists", entry.Name)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if _, err := os.Stat(srcPath); err != nil {
+			return nil, fmt.Errorf("marketplace entry %q points to missing path %s", entry.Name, entry.Source.Path)
+		}
+		if err := fsutil.CopyDirRecursive(srcPath, destPath); err != nil {
+			return nil, fmt.Errorf("copying plugin %q: %w", entry.Name, err)
+		}
+		entry.Source.Path = "./plugins/" + entry.Name
+		importedEntries = append(importedEntries, entry)
+		installed = append(installed, Plugin{Name: entry.Name, Dir: destPath})
+	}
+
+	if len(installed) == 0 {
+		return nil, fmt.Errorf("no matching plugins found in marketplace")
+	}
+
+	projectMarketplacePath, _ := projectMarketplaceFile(projectDir, agentName)
+	if err := mergeMarketplace(projectMarketplacePath, importedEntries); err != nil {
+		return nil, err
+	}
+
+	return installed, nil
+}
+
+// Remove deletes a project plugin and removes its marketplace entry.
+func Remove(projectDir, agentName, name string) error {
+	root, err := ProjectPluginsDir(projectDir, agentName)
+	if err != nil {
+		return err
+	}
+	if err := validatePluginName(name); err != nil {
+		return err
+	}
+
+	dest := filepath.Join(root, name)
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		return fmt.Errorf("plugin %q not found", name)
+	}
+	if err := os.RemoveAll(dest); err != nil {
+		return err
+	}
+
+	marketplacePath, err := projectMarketplaceFile(projectDir, agentName)
+	if err != nil {
+		return err
+	}
+	return removeMarketplaceEntry(marketplacePath, name)
+}
+
+func validatePluginName(name string) error {
+	if name == "" || name == "." || name == ".." {
+		return fmt.Errorf("invalid plugin name %q", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, `\`) {
+		return fmt.Errorf("plugin name %q cannot contain path separators", name)
+	}
+	return nil
+}
+
+func mergeMarketplace(path string, newEntries []marketplaceItem) error {
+	current, err := loadMarketplace(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if current.Name == "" {
+		current.Name = "local-plugins"
+	}
+	if current.Interface.DisplayName == "" {
+		current.Interface.DisplayName = "Local Plugins"
+	}
+
+	existing := make(map[string]bool, len(current.Plugins))
+	for _, entry := range current.Plugins {
+		existing[entry.Name] = true
+	}
+	for _, entry := range newEntries {
+		if !existing[entry.Name] {
+			current.Plugins = append(current.Plugins, entry)
+			existing[entry.Name] = true
+		}
+	}
+	return saveMarketplace(path, current)
+}
+
+func removeMarketplaceEntry(path, name string) error {
+	current, err := loadMarketplace(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	filtered := current.Plugins[:0]
+	for _, entry := range current.Plugins {
+		if entry.Name != name {
+			filtered = append(filtered, entry)
+		}
+	}
+	current.Plugins = filtered
+	return saveMarketplace(path, current)
+}
+
+func loadMarketplace(path string) (marketplace, error) {
+	var m marketplace
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return m, err
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return m, fmt.Errorf("parsing marketplace file %s: %w", path, err)
+	}
+	return m, nil
+}
+
+func saveMarketplace(path string, m marketplace) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating marketplace dir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding marketplace file: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing marketplace file: %w", err)
+	}
+	return nil
+}

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,140 @@
+package plugins
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectPluginsDir_Codex(t *testing.T) {
+	projectDir := t.TempDir()
+	got, err := ProjectPluginsDir(projectDir, "codex")
+	if err != nil {
+		t.Fatalf("ProjectPluginsDir returned error: %v", err)
+	}
+	want := filepath.Join(projectDir, "plugins")
+	if got != want {
+		t.Fatalf("ProjectPluginsDir = %q, want %q", got, want)
+	}
+}
+
+func TestProjectPluginsDir_UnsupportedAgent(t *testing.T) {
+	if _, err := ProjectPluginsDir(t.TempDir(), "claude"); err == nil {
+		t.Fatal("ProjectPluginsDir should reject unsupported agents")
+	}
+}
+
+func TestInstallListAndRemove(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	projectDir := t.TempDir()
+	repo := initMarketplaceRepo(t, "caveman-repo")
+
+	installed, err := Install(projectDir, "codex", repo, "")
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if len(installed) != 1 || installed[0].Name != "caveman" {
+		t.Fatalf("Install = %#v, want caveman", installed)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, "plugins", "caveman", ".codex-plugin", "plugin.json")); err != nil {
+		t.Fatalf("expected plugin payload in project plugins dir: %v", err)
+	}
+
+	marketplacePath := filepath.Join(projectDir, ".agents", "plugins", "marketplace.json")
+	data, err := os.ReadFile(marketplacePath)
+	if err != nil {
+		t.Fatalf("expected marketplace file: %v", err)
+	}
+	var m struct {
+		Plugins []struct {
+			Name   string `json:"name"`
+			Source struct {
+				Path string `json:"path"`
+			} `json:"source"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("invalid marketplace json: %v", err)
+	}
+	if len(m.Plugins) != 1 || m.Plugins[0].Name != "caveman" || m.Plugins[0].Source.Path != "./plugins/caveman" {
+		t.Fatalf("unexpected marketplace content: %#v", m.Plugins)
+	}
+
+	listed, err := List(projectDir, "codex")
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "caveman" {
+		t.Fatalf("List = %#v, want caveman", listed)
+	}
+
+	if err := Remove(projectDir, "codex", "caveman"); err != nil {
+		t.Fatalf("Remove returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, "plugins", "caveman")); !os.IsNotExist(err) {
+		t.Fatalf("plugin dir still exists after remove: %v", err)
+	}
+}
+
+func initMarketplaceRepo(t *testing.T, name string) string {
+	t.Helper()
+
+	repo := filepath.Join(t.TempDir(), name)
+	marketplacePath := filepath.Join(repo, ".agents", "plugins")
+	pluginPath := filepath.Join(repo, "plugins", "caveman", ".codex-plugin")
+
+	if err := os.MkdirAll(marketplacePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pluginPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	marketplaceJSON := `{
+  "name": "caveman-repo",
+  "interface": {
+    "displayName": "Caveman Repo"
+  },
+  "plugins": [
+    {
+      "name": "caveman",
+      "source": {
+        "source": "local",
+        "path": "./plugins/caveman"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(marketplacePath, "marketplace.json"), []byte(marketplaceJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginPath, "plugin.json"), []byte(`{"name":"caveman"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test User")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "init")
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}

--- a/internal/profile/dockerfile.go
+++ b/internal/profile/dockerfile.go
@@ -122,7 +122,13 @@ RUN set -e && \
 		return `RUN npm install -g typescript eslint prettier yarn pnpm
 `
 	case "ml":
-		return "# ML profile uses build-tools for compilation\n"
+		// Install AI/ML Python tooling into the venv created by the python profile.
+		// huggingface_hub[cli] provides the `huggingface-cli` command.
+		return `# ML profile - AI/ML tooling (huggingface-cli, etc.) into python venv
+RUN /home/user/.venv/bin/pip install --no-cache-dir \
+    "huggingface_hub[cli]" \
+    safetensors
+`
 	}
 	return ""
 }

--- a/internal/skills/fetch.go
+++ b/internal/skills/fetch.go
@@ -28,7 +28,10 @@ import (
 	"time"
 )
 
-var githubTreeRE = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/tree/([^/]+)/(.+)$`)
+var (
+	githubTreeRE = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/tree/([^/]+)/(.+)$`)
+	githubBlobRE = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$`)
+)
 
 // SourceType identifies the type of skill source.
 type SourceType int
@@ -36,6 +39,7 @@ type SourceType int
 const (
 	SourceUnknown    SourceType = iota
 	SourceGitHubTree            // GitHub tree URL (directory)
+	SourceGitHubBlob            // GitHub blob URL (single file)
 	SourceRawURL                // Direct URL to a file
 	SourceLocalPath             // Local filesystem path
 )
@@ -44,6 +48,9 @@ const (
 func DetectSource(input string) SourceType {
 	if githubTreeRE.MatchString(input) {
 		return SourceGitHubTree
+	}
+	if githubBlobRE.MatchString(input) {
+		return SourceGitHubBlob
 	}
 	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
 		return SourceRawURL
@@ -62,6 +69,8 @@ func Fetch(source string) (*FetchResult, error) {
 	switch DetectSource(source) {
 	case SourceGitHubTree:
 		return fetchGitHubTree(source)
+	case SourceGitHubBlob:
+		return fetchGitHubBlob(source)
 	case SourceRawURL:
 		return fetchRawURL(source)
 	case SourceLocalPath:
@@ -132,6 +141,45 @@ func githubFetchDir(owner, repo, ref, dirPath, prefix string, files map[string][
 		}
 	}
 	return nil
+}
+
+// fetchGitHubBlob handles GitHub blob URLs (single file view) like:
+// https://github.com/user/repo/blob/main/path/to/SKILL.md
+// Converts to raw.githubusercontent.com URL to get the actual content.
+func fetchGitHubBlob(url string) (*FetchResult, error) {
+	m := githubBlobRE.FindStringSubmatch(url)
+	if m == nil {
+		return nil, fmt.Errorf("invalid GitHub blob URL: %s", url)
+	}
+	owner, repo, ref, filePath := m[1], m[2], m[3], m[4]
+
+	rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", owner, repo, ref, filePath)
+	content, err := httpGet(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("downloading %s: %w", rawURL, err)
+	}
+
+	// Derive name from frontmatter or parent directory in the path.
+	name := ""
+	if fmName, _ := parseFrontmatter(content); fmName != "" {
+		name = fmName
+	}
+	if name == "" {
+		// Use parent directory: "skills/frontend-design/SKILL.md" → "frontend-design"
+		dir := filepath.Dir(filePath)
+		if dir != "." && dir != "/" {
+			name = filepath.Base(dir)
+		} else {
+			name = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+		}
+	}
+
+	// Use the original filename as the key (preserves SKILL.md vs custom names).
+	fileName := filepath.Base(filePath)
+	return &FetchResult{
+		Name:  name,
+		Files: map[string][]byte{fileName: content},
+	}, nil
 }
 
 // fetchRawURL handles direct URLs to a SKILL.md file.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -102,6 +102,8 @@ func TestDetectSource(t *testing.T) {
 	}{
 		{"https://github.com/anthropics/skills/tree/main/skills/frontend-design", SourceGitHubTree},
 		{"http://github.com/user/repo/tree/dev/path/to/skill", SourceGitHubTree},
+		{"https://github.com/user/repo/blob/main/skills/my-skill/SKILL.md", SourceGitHubBlob},
+		{"https://github.com/rohitg00/awesome/blob/main/agents/infra/k8s.md", SourceGitHubBlob},
 		{"https://example.com/SKILL.md", SourceRawURL},
 		{"https://raw.githubusercontent.com/user/repo/main/SKILL.md", SourceRawURL},
 		{"/home/user/skills/my-skill", SourceLocalPath},

--- a/internal/wizard/roles.go
+++ b/internal/wizard/roles.go
@@ -124,6 +124,13 @@ var Roles = []Role{
 		Languages:      []string{"Python", "Go"},
 		ToolCategories: []string{"Networking", "Security", "Shell Utils"},
 	},
+	{
+		Name:           "AI Developer",
+		Description:    "AI/ML development (huggingface-cli, model tooling)",
+		Profiles:       []string{"python", "ml", "build-tools"},
+		Languages:      []string{"Python"},
+		ToolCategories: []string{"Build Tools"},
+	},
 }
 
 // AllLanguages defines the available language choices.
@@ -166,11 +173,18 @@ type ExternalTool struct {
 	Name        string
 	Description string
 	Packages    []string             // Alpine APK packages
+	InstallStep string               // Additional Dockerfile RUN instruction
 	Configs     []ExternalToolConfig // Host configs to detect (for UI hints)
 }
 
 // AllExternalTools defines the available external tools.
 var AllExternalTools = []ExternalTool{
+	{
+		Name:        "Bun",
+		Description: "bun — JavaScript runtime and package manager",
+		Packages:    []string{"nodejs", "npm"},
+		InstallStep: "RUN npm install -g bun\n",
+	},
 	{
 		Name:        "GitHub CLI",
 		Description: "gh — GitHub from the command line",
@@ -296,6 +310,27 @@ func ComputeExternalToolPackages(names []string) []string {
 						seen[pkg] = true
 						result = append(result, pkg)
 					}
+				}
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+// ComputeExternalToolInstallSteps returns additional Dockerfile snippets
+// required by selected external tools.
+func ComputeExternalToolInstallSteps(names []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, name := range names {
+		for _, et := range AllExternalTools {
+			if et.Name == name {
+				if et.InstallStep != "" && !seen[et.InstallStep] {
+					seen[et.InstallStep] = true
+					result = append(result, et.InstallStep)
 				}
 				break
 			}

--- a/internal/wizard/roles_test.go
+++ b/internal/wizard/roles_test.go
@@ -15,9 +15,32 @@ import (
 )
 
 func TestComputeExternalToolPackages_Valid(t *testing.T) {
-	pkgs := ComputeExternalToolPackages([]string{"GitHub CLI"})
-	if len(pkgs) != 1 || pkgs[0] != "github-cli" {
-		t.Errorf("ComputeExternalToolPackages(GitHub CLI) = %v, want [github-cli]", pkgs)
+	pkgs := ComputeExternalToolPackages([]string{"Bun", "GitHub CLI"})
+	want := []string{"nodejs", "npm", "github-cli"}
+	if len(pkgs) != len(want) {
+		t.Fatalf("ComputeExternalToolPackages(Bun, GitHub CLI) = %v, want %v", pkgs, want)
+	}
+	for i := range want {
+		if pkgs[i] != want[i] {
+			t.Fatalf("ComputeExternalToolPackages(Bun, GitHub CLI) = %v, want %v", pkgs, want)
+		}
+	}
+}
+
+func TestComputeExternalToolInstallSteps_Valid(t *testing.T) {
+	steps := ComputeExternalToolInstallSteps([]string{"Bun", "GitHub CLI"})
+	if len(steps) != 1 {
+		t.Fatalf("ComputeExternalToolInstallSteps(Bun, GitHub CLI) = %v, want one step", steps)
+	}
+	if steps[0] != "RUN npm install -g bun\n" {
+		t.Fatalf("ComputeExternalToolInstallSteps(Bun, GitHub CLI) = %q, want bun install step", steps[0])
+	}
+}
+
+func TestComputeExternalToolInstallSteps_Unknown(t *testing.T) {
+	steps := ComputeExternalToolInstallSteps([]string{"Unknown Tool"})
+	if steps != nil {
+		t.Errorf("ComputeExternalToolInstallSteps(Unknown Tool) = %v, want nil", steps)
 	}
 }
 
@@ -73,5 +96,49 @@ func TestDetectExternalToolConfigs_NothingDetected(t *testing.T) {
 	detected := DetectExternalToolConfigs()
 	if detected != nil {
 		t.Errorf("DetectExternalToolConfigs() with empty home = %v, want nil", detected)
+	}
+}
+
+func TestAIDeveloperRole(t *testing.T) {
+	role := GetRole("AI Developer")
+	if role == nil {
+		t.Fatal("AI Developer role not found")
+	}
+
+	// Verify python comes before ml so the venv exists when ml's pip install runs.
+	pythonIdx, mlIdx := -1, -1
+	for i, p := range role.Profiles {
+		if p == "python" {
+			pythonIdx = i
+		}
+		if p == "ml" {
+			mlIdx = i
+		}
+	}
+	if pythonIdx < 0 {
+		t.Error("AI Developer role must include 'python' profile")
+	}
+	if mlIdx < 0 {
+		t.Error("AI Developer role must include 'ml' profile")
+	}
+	if pythonIdx >= 0 && mlIdx >= 0 && pythonIdx >= mlIdx {
+		t.Errorf("python profile (%d) must come before ml profile (%d)", pythonIdx, mlIdx)
+	}
+}
+
+func TestComputeProfiles_AIDeveloper(t *testing.T) {
+	profiles := ComputeProfiles([]string{"AI Developer"}, nil)
+	wantContains := []string{"python", "ml", "build-tools"}
+	for _, want := range wantContains {
+		found := false
+		for _, p := range profiles {
+			if p == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("ComputeProfiles(AI Developer) missing %q, got %v", want, profiles)
+		}
 	}
 }

--- a/static/build/docker-entrypoint
+++ b/static/build/docker-entrypoint
@@ -87,6 +87,15 @@ set -g pane-border-style "fg=colour236"
 set -g pane-active-border-style "fg=colour236"
 set -g message-style "bg=colour236,fg=colour255"
 set -g allow-passthrough on
+set -g set-clipboard on
+# Word separators: exclude URL characters so double-click selects entire URLs.
+set -g word-separators " '\"<>{}()|"
+# Disable right-click context menu so the terminal's native menu works
+# (copy, paste, open URL, etc.).
+unbind -n MouseDown3Pane
+unbind -n MouseDown3StatusLeft
+unbind -n MouseDown3StatusRight
+unbind -n MouseDown3Status
 TMUXEOF
 
     if [[ "${EXITBOX_STATUS_BAR:-true}" != "true" ]]; then
@@ -308,11 +317,15 @@ apply_active_workspace_links() {
 
     case "$AGENT" in
         claude)
-            mkdir -p "$workspace_root/.claude" "$workspace_root/.config"
+            mkdir -p "$workspace_root/.claude" "$workspace_root/.config" \
+                     "$workspace_root/.cache"
             touch "$workspace_root/.claude.json"
             link_path "$workspace_root/.claude" "$HOME/.claude"
             link_path "$workspace_root/.claude.json" "$HOME/.claude.json"
             link_path "$workspace_root/.config" "$HOME/.config"
+            # Persist ~/.cache so MCP OAuth tokens (stored in
+            # ~/.cache/claude-cli-nodejs/) survive across sessions.
+            link_path "$workspace_root/.cache" "$HOME/.cache"
             ;;
         codex)
             mkdir -p "$workspace_root/.codex" "$workspace_root/.config/codex"
@@ -334,6 +347,74 @@ apply_active_workspace_links() {
             link_path "$workspace_root/.cache/opencode" "$HOME/.cache/opencode"
             ;;
     esac
+
+    # Share gh CLI auth across agents. Claude's workspace has the full
+    # ~/.config/ (including ~/.config/gh/) but Codex/OpenCode only mount
+    # their own subdirs. Link gh config from Claude's workspace if present.
+    if [[ "$AGENT" != "claude" ]] && [[ ! -d "$HOME/.config/gh" ]]; then
+        local claude_gh="${GLOBAL_WORKSPACE_ROOT}/${name}/claude/.config/gh"
+        if [[ -d "$claude_gh" ]]; then
+            mkdir -p "$HOME/.config"
+            link_path "$claude_gh" "$HOME/.config/gh"
+        fi
+    fi
+}
+
+codex_session_storage_name() {
+    local name
+    name="$(current_session_name)"
+    if [[ -z "$name" && "${EXITBOX_AUTO_RESUME:-false}" == "true" ]]; then
+        name="$(get_active_session_name)"
+    fi
+    if [[ -z "$name" ]]; then
+        name="$(default_session_name)"
+    fi
+    echo "$name"
+}
+
+codex_uses_direct_home() {
+    [[ "$AGENT" != "codex" ]] && return 1
+    case "${1:-}" in
+        login|logout|auth)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+configure_codex_session_storage() {
+    [[ "$AGENT" != "codex" ]] && return 0
+    codex_uses_direct_home "$@" && return 0
+    [[ -e "$HOME/.codex" ]] || return 0
+
+    local shared_root session_name session_key overlay_root state_root item base
+    shared_root="$(readlink -f "$HOME/.codex" 2>/dev/null || printf '%s' "$HOME/.codex")"
+    [[ -d "$shared_root" ]] || return 0
+
+    session_name="$(codex_session_storage_name)"
+    [[ -n "$session_name" ]] || return 0
+    export EXITBOX_SESSION_NAME="$session_name"
+
+    session_key="$(session_key_for_name "$session_name")"
+    overlay_root="${shared_root}/.exitbox/session-home/${session_key}"
+    state_root="${shared_root}/.exitbox/session-data/${session_key}"
+    mkdir -p "$overlay_root" "${state_root}/sessions"
+
+    shopt -s nullglob
+    for item in "$shared_root"/* "$shared_root"/.[!.]* "$shared_root"/..?*; do
+        [[ -e "$item" ]] || continue
+        base="$(basename "$item")"
+        case "$base" in
+            .|..|sessions|.exitbox)
+                continue
+                ;;
+        esac
+        ln -sfn "$item" "${overlay_root}/${base}"
+    done
+    shopt -u nullglob
+
+    link_path "${state_root}/sessions" "${overlay_root}/sessions"
+    link_path "$overlay_root" "$HOME/.codex"
 }
 
 link_skills() {
@@ -663,6 +744,8 @@ capture_resume_token() {
 }
 
 build_resume_args() {
+    codex_uses_direct_home "$@" && return
+
     # Session resume resolution (called from run_agent_loop):
     #
     # Priority order:
@@ -791,6 +874,7 @@ run_agent_once() {
 
 run_agent_loop() {
     apply_active_workspace_links
+    configure_codex_session_storage "$@"
     update_tmux_status
     if [[ -n "$AGENT" ]]; then
         inject_sandbox_instructions
@@ -798,7 +882,7 @@ run_agent_loop() {
         link_skills
     fi
 
-    build_resume_args
+    build_resume_args "$@"
 
     # Check if user already passed resume-related flags in their args
     local user_has_resume=false
@@ -1046,6 +1130,15 @@ You are running inside an ExitBox sandboxed container. Important constraints:
   user. NEVER show raw secret values in your responses, tool outputs, or summaries.
   Examples: \`Authorization: Bearer <redacted>\`, \`password: <redacted>\`,
   \`API_KEY=<redacted>\`. This applies to ALL contexts — code output, logs, configs, etc.
+- MCP SERVERS: MCP servers CAN work inside this sandbox. Do NOT tell the user that
+  MCP servers are unavailable or that the sandbox prevents them from working.
+  If an MCP server fails to connect, the most likely cause is that its API domain
+  is not in the firewall allowlist. Use \`exitbox-allow <domain>\` to request access
+  for the provider's root domain (e.g. \`exitbox-allow atlassian.net\` for Atlassian,
+  \`exitbox-allow linear.app\` for Linear, \`exitbox-allow slack.com\` for Slack).
+  MCP auth tokens are stored in the agent config directory which is mounted into
+  the container. If auth fails, the user may need to re-authenticate — do not assume
+  it is impossible. Guide the user through the auth flow instead of giving up.
 - Focus on writing, testing, and debugging code within /workspace. That is your scope.
 <!-- END-EXITBOX-SANDBOX -->
 "
@@ -1518,6 +1611,7 @@ fi
 
 if [[ -n "$AGENT" ]]; then
     apply_active_workspace_links
+    configure_codex_session_storage "$@"
     inject_sandbox_instructions
     inject_codex_approval_rules
     link_skills

--- a/static/build/docker-entrypoint_test.sh
+++ b/static/build/docker-entrypoint_test.sh
@@ -78,29 +78,41 @@ CAPTURE_FUNC="$(extract_func capture_resume_token)"
 BUILD_FUNC="$(extract_func build_resume_args)"
 DISPLAY_FUNC="$(extract_func agent_display_name)"
 TMUX_CONF_FUNC="$(extract_func write_tmux_conf)"
+LINK_PATH_FUNC="$(extract_func link_path)"
 DEFAULT_SESSION_NAME_FUNC="$(extract_func default_session_name)"
 CURRENT_SESSION_NAME_FUNC="$(extract_func current_session_name)"
 EFFECTIVE_SESSION_NAME_FUNC="$(extract_func effective_session_name)"
 PROJECT_RESUME_DIR_FUNC="$(extract_func project_resume_dir)"
 ACTIVE_SESSION_FILE_FUNC="$(extract_func active_session_file)"
+KV_SESSION_PREFIX_FUNC="$(extract_func kv_session_prefix)"
 SET_ACTIVE_SESSION_NAME_FUNC="$(extract_func set_active_session_name)"
 GET_ACTIVE_SESSION_NAME_FUNC="$(extract_func get_active_session_name)"
 SESSION_KEY_FOR_NAME_FUNC="$(extract_func session_key_for_name)"
 SESSION_DIR_FOR_NAME_FUNC="$(extract_func session_dir_for_name)"
 ENSURE_NAMED_SESSION_DIR_FUNC="$(extract_func ensure_named_session_dir)"
 LEGACY_RESUME_FILE_FUNC="$(extract_func legacy_resume_file)"
+CODEX_SESSION_STORAGE_NAME_FUNC="$(extract_func codex_session_storage_name)"
+CODEX_USES_DIRECT_HOME_FUNC="$(extract_func codex_uses_direct_home)"
+CONFIGURE_CODEX_SESSION_STORAGE_FUNC="$(extract_func configure_codex_session_storage)"
 
 SESSION_HELPER_FUNCS="${DEFAULT_SESSION_NAME_FUNC}
 ${CURRENT_SESSION_NAME_FUNC}
 ${EFFECTIVE_SESSION_NAME_FUNC}
 ${PROJECT_RESUME_DIR_FUNC}
 ${ACTIVE_SESSION_FILE_FUNC}
+${KV_SESSION_PREFIX_FUNC}
 ${SET_ACTIVE_SESSION_NAME_FUNC}
 ${GET_ACTIVE_SESSION_NAME_FUNC}
 ${SESSION_KEY_FOR_NAME_FUNC}
 ${SESSION_DIR_FOR_NAME_FUNC}
 ${ENSURE_NAMED_SESSION_DIR_FUNC}
-${LEGACY_RESUME_FILE_FUNC}"
+${LEGACY_RESUME_FILE_FUNC}
+${CODEX_USES_DIRECT_HOME_FUNC}"
+
+CODEX_SESSION_HELPERS="${LINK_PATH_FUNC}
+${SESSION_HELPER_FUNCS}
+${CODEX_SESSION_STORAGE_NAME_FUNC}
+${CONFIGURE_CODEX_SESSION_STORAGE_FUNC}"
 
 session_key_for_test() {
     local name="$1"
@@ -521,6 +533,120 @@ test_build_resume_args_project_scoped_reads_scoped_token() {
 }
 
 # ============================================================================
+# Test: configure_codex_session_storage isolates named sessions
+# ============================================================================
+test_configure_codex_session_storage_isolates_named_sessions() {
+    local tmpdir="$TEST_TMPDIR/codex_storage_named"
+    local home="$tmpdir/home"
+    local shared="$tmpdir/shared-codex"
+    local session_name="infra"
+    local session_key
+    session_key="$(session_key_for_test "$session_name")"
+
+    mkdir -p "$home" "$shared/sessions/legacy"
+    echo "model = \"gpt-5\"" > "$shared/config.toml"
+    ln -s "$shared" "$home/.codex"
+
+    local result
+    result="$(
+        AGENT="codex"
+        HOME="$home"
+        EXITBOX_SESSION_NAME="$session_name"
+        eval "$CODEX_SESSION_HELPERS"
+        configure_codex_session_storage
+        printf 'codex=%s\n' "$(readlink -f "$HOME/.codex")"
+        printf 'config=%s\n' "$(readlink -f "$HOME/.codex/config.toml")"
+        printf 'sessions=%s\n' "$(readlink -f "$HOME/.codex/sessions")"
+    )" 2>/dev/null
+
+    assert_contains "configure_codex_session_storage (named overlay)" \
+        "$result" "codex=${shared}/.exitbox/session-home/${session_key}"
+    assert_contains "configure_codex_session_storage (shared config)" \
+        "$result" "config=${shared}/config.toml"
+    assert_contains "configure_codex_session_storage (isolated sessions)" \
+        "$result" "sessions=${shared}/.exitbox/session-data/${session_key}/sessions"
+}
+
+# ============================================================================
+# Test: configure_codex_session_storage uses active session for bare resume
+# ============================================================================
+test_configure_codex_session_storage_uses_active_session() {
+    local tmpdir="$TEST_TMPDIR/codex_storage_active"
+    local home="$tmpdir/home"
+    local shared="$tmpdir/shared-codex"
+    local active_name="exitmail"
+    local session_key
+    session_key="$(session_key_for_test "$active_name")"
+
+    mkdir -p "$home" "$shared" "$tmpdir/default/codex"
+    ln -s "$shared" "$home/.codex"
+    echo "$active_name" > "$tmpdir/default/codex/.active-session"
+
+    local result
+    result="$(
+        AGENT="codex"
+        HOME="$home"
+        GLOBAL_WORKSPACE_ROOT="$tmpdir"
+        EXITBOX_WORKSPACE_NAME="default"
+        EXITBOX_AUTO_RESUME="true"
+        EXITBOX_SESSION_NAME=""
+        eval "$CODEX_SESSION_HELPERS"
+        configure_codex_session_storage
+        printf 'session=%s\n' "$EXITBOX_SESSION_NAME"
+        printf 'sessions=%s\n' "$(readlink -f "$HOME/.codex/sessions")"
+    )" 2>/dev/null
+
+    assert_contains "configure_codex_session_storage (active session name)" \
+        "$result" "session=${active_name}"
+    assert_contains "configure_codex_session_storage (active session path)" \
+        "$result" "sessions=${shared}/.exitbox/session-data/${session_key}/sessions"
+}
+
+# ============================================================================
+# Test: configure_codex_session_storage bypasses overlay for login/logout flows
+# ============================================================================
+test_configure_codex_session_storage_bypasses_login_flow() {
+    local tmpdir="$TEST_TMPDIR/codex_storage_login"
+    local home="$tmpdir/home"
+    local shared="$tmpdir/shared-codex"
+
+    mkdir -p "$home" "$shared"
+    ln -s "$shared" "$home/.codex"
+
+    local result
+    result="$(
+        AGENT="codex"
+        HOME="$home"
+        EXITBOX_SESSION_NAME="login-run"
+        eval "$CODEX_SESSION_HELPERS"
+        configure_codex_session_storage login
+        printf 'codex=%s\n' "$(readlink -f "$HOME/.codex")"
+    )" 2>/dev/null
+
+    assert_contains "configure_codex_session_storage (login keeps shared home)" \
+        "$result" "codex=${shared}"
+}
+
+# ============================================================================
+# Test: build_resume_args does not inject resume flags into codex login
+# ============================================================================
+test_build_resume_args_skips_codex_login() {
+    local result
+    result="$(
+        AGENT="codex"
+        EXITBOX_AUTO_RESUME="true"
+        EXITBOX_RESUME_TOKEN="last"
+        eval "$SESSION_HELPER_FUNCS"
+        eval "$CODEX_USES_DIRECT_HOME_FUNC"
+        eval "$BUILD_FUNC"
+        build_resume_args login
+        echo "${RESUME_ARGS[*]}"
+    )" 2>/dev/null
+
+    assert_eq "build_resume_args (codex login has no resume args)" "" "$result"
+}
+
+# ============================================================================
 # Test: write_tmux_conf includes scrolling settings
 # ============================================================================
 test_write_tmux_conf_scroll_settings() {
@@ -634,6 +760,10 @@ test_capture_resume_token_project_scoped
 test_build_resume_args_named_session_no_legacy_fallback
 test_build_resume_args_active_session_legacy_fallback
 test_build_resume_args_project_scoped_reads_scoped_token
+test_configure_codex_session_storage_isolates_named_sessions
+test_configure_codex_session_storage_uses_active_session
+test_configure_codex_session_storage_bypasses_login_flow
+test_build_resume_args_skips_codex_login
 test_write_tmux_conf_scroll_settings
 test_parse_keybindings_default
 test_parse_keybindings_custom


### PR DESCRIPTION
## Summary

- **Squid proxy reliability**: subdomain dedup prevents FATAL config errors, skip reconfigure when unchanged, auto-restart on stale PID, DNS caching
- **OAuth authentication**: publish callback ports for OpenCode/Codex with socat relay, port availability check, xdg-open stub for URL display
- **Skill management**: GitHub blob URL support (converts to raw), recursive tree fetch for nested dirs, per-skill symlinks into agent config dirs
- **MCP server support**: persist ~/.cache for Claude so OAuth tokens survive sessions, sandbox instructions confirm MCP works in sandbox
- **tmux UX**: OSC 52 clipboard, URL-friendly word separators, disable right-click menu passthrough
- **Sandbox instructions**: root-domain-only for exitbox-allow, share gh auth across agents, MCP guidance

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `exitbox run opencode -- auth login` completes OAuth flow with firewall active
- [ ] `exitbox skills install https://github.com/anthropics/skills/tree/main/skills/frontend-design` fetches all files including nested dirs
- [ ] `exitbox skills install https://github.com/user/repo/blob/main/SKILL.md` fetches markdown, not HTML
- [ ] Squid reconfigure warning no longer appears on repeated runs with unchanged config
- [ ] Allowlist with subdomain+parent domain (e.g. icy-veins.com + www.icy-veins.com) does not crash squid
- [ ] MCP server auth persists across container restarts (Claude)
- [ ] Right-click in tmux passes through to terminal native menu