### PR TITLE
fix: config edit targets the default env profile

### DIFF
--- a/cmd/config_cmd.go
+++ b/cmd/config_cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cloud-exit/exitbox/internal/agents"
 	"github.com/cloud-exit/exitbox/internal/config"
+	"github.com/cloud-exit/exitbox/internal/env"
 	"github.com/cloud-exit/exitbox/internal/profile"
 	"github.com/cloud-exit/exitbox/internal/ui"
 	"github.com/spf13/cobra"
@@ -173,6 +174,17 @@ Examples:
 			cfg := config.LoadOrDefault()
 			workspaceName := resolveConfigWorkspace(cfg, workspace)
 
+			// With no explicit --profile, target the workspace's default env
+			// profile so `config edit` edits the same config that `exitbox run`
+			// loads (run auto-applies the default profile). Falls back to the
+			// base config only when no default profile is set.
+			if envProfile == "" {
+				if defName := defaultEnvProfile(workspaceName); defName != "" {
+					envProfile = defName
+					ui.Infof("Editing default env profile '%s' (use --profile to override)", defName)
+				}
+			}
+
 			if envProfile != "" {
 				if err := validateProfileName(envProfile); err != nil {
 					ui.Errorf("%v", err)
@@ -256,6 +268,18 @@ func resolveConfigWorkspace(cfg *config.Config, override string) string {
 		return cfg.Workspaces.Items[0].Name
 	}
 	return "default"
+}
+
+// defaultEnvProfile returns the workspace's default env profile name, or "" if
+// none is set. Mirrors what `exitbox run` resolves so config edits target the
+// same profile-scoped config the agent loads at runtime.
+func defaultEnvProfile(workspaceName string) string {
+	defName, err := env.GetDefault(workspaceName)
+	if err != nil {
+		ui.Warnf("Could not read default env profile: %v", err)
+		return ""
+	}
+	return defName
 }
 
 func init() {

--- a/cmd/config_cmd_test.go
+++ b/cmd/config_cmd_test.go
@@ -1,0 +1,50 @@
+// ExitBox - Multi-Agent Container Sandbox
+// Copyright (C) 2026 Cloud Exit B.V.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cloud-exit/exitbox/internal/config"
+	"github.com/cloud-exit/exitbox/internal/env"
+)
+
+// TestDefaultEnvProfile verifies that `config edit` (via defaultEnvProfile) targets
+// the workspace's default env profile, matching what `exitbox run` loads.
+func TestDefaultEnvProfile(t *testing.T) {
+	oldData := config.Data
+	config.Data = t.TempDir()
+	t.Cleanup(func() { config.Data = oldData })
+
+	ws := "ws-config-edit-test"
+
+	// No default set → empty (falls back to base config).
+	if got := defaultEnvProfile(ws); got != "" {
+		t.Errorf("defaultEnvProfile with no default = %q, want \"\"", got)
+	}
+
+	// Save a profile and mark it default → it is returned.
+	if err := env.Save(ws, &env.Profile{Name: "openrouter", Vars: map[string]string{"OPENAI_API_KEY": "x"}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := env.SetDefault(ws, "openrouter"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	if got := defaultEnvProfile(ws); got != "openrouter" {
+		t.Errorf("defaultEnvProfile = %q, want openrouter", got)
+	}
+}


### PR DESCRIPTION
`exitbox config edit <agent>` (no `--profile`) edited the base workspace config, but `exitbox run` auto-applies the workspace's **default env profile** (e.g. `openrouter`) and reads the profile-scoped config. So edits landed in a file the agent never loads at runtime.

## Fix

`config edit` now resolves the workspace's default env profile (via `env.GetDefault`, the same call `run` uses) when `--profile` is not given, and edits that profile's config. Falls back to the base config only when no default profile is set. `--profile` still overrides explicitly.

Prints `Editing default env profile '<name>' (use --profile to override)` so the target is obvious.

## Note

`exitbox generate <agent>` and `config import` write to the base config the same way and have the same base-vs-default-profile mismatch. Left unchanged here (not requested); can be aligned in a follow-up if wanted.

## Tests

- New `TestDefaultEnvProfile` (cmd): no default → empty; profile marked default → returned.
- `go build`, `go test ./...`, `go vet`, `golangci-lint` green.