### PR TITLE
fix: advertise tmux extkeys for all terminals (Shift+Enter)

### DIFF
--- a/static/build/docker-entrypoint
+++ b/static/build/docker-entrypoint
@@ -75,9 +75,11 @@ write_tmux_conf() {
 # ExitBox tmux configuration
 set -g default-terminal "xterm-256color"
 # Forward modified keys (e.g. Shift+Enter / Alt+Enter) to agent TUIs that request
-# them. Without extended-keys, those agents warn and the modified Enter is lost.
+# them (Kitty keyboard protocol). The "*" pattern advertises extkeys for every
+# outer terminal that supports it, not just xterm-named ones, so Shift+Enter
+# reaches agents like Pi regardless of TERM. (Ctrl+J is the universal fallback.)
 set -g extended-keys on
-set -as terminal-features "xterm*:extkeys"
+set -as terminal-features "*:extkeys"
 set -g status-position top
 set -g status-style "bg=colour236,fg=colour255"
 set -g status-left " ExitBox  ${display} "

--- a/static/build/docker-entrypoint_test.sh
+++ b/static/build/docker-entrypoint_test.sh
@@ -743,7 +743,7 @@ test_write_tmux_conf_scroll_settings() {
     assert_contains "write_tmux_conf enables mouse scrolling" "$output" 'set -g mouse on'
     assert_contains "write_tmux_conf sets large history" "$output" 'set -g history-limit 100000'
     assert_contains "write_tmux_conf enables extended-keys" "$output" 'set -g extended-keys on'
-    assert_contains "write_tmux_conf advertises extkeys terminal feature" "$output" 'extkeys'
+    assert_contains "write_tmux_conf advertises extkeys for all terminals" "$output" 'terminal-features "*:extkeys"'
     assert_contains "write_tmux_conf shows workspace shortcut" "$output" 'C-M-p: workspaces'
     assert_contains "write_tmux_conf shows session shortcut" "$output" 'C-M-s: sessions'
 }


### PR DESCRIPTION
`Shift+Enter` didn't reach agent TUIs (e.g. Pi) inside ExitBox's tmux. The generated tmux config advertised the Kitty extended-keys feature only for `xterm*` terminals (`terminal-features "xterm*:extkeys"`), so terminals whose `TERM` isn't `xterm*` never had extended keys negotiated, and modified-Enter was lost.

## Fix
Advertise extkeys for all terminals: `set -as terminal-features "*:extkeys"` (matches Pi's documented tmux recommendation). `set -g extended-keys on` unchanged. Terminals that don't support the protocol simply don't get it negotiated — no regression. `Ctrl+J` remains the universal newline fallback (Pi binds it by default).

## Tests
Updated `write_tmux_conf` assertion to check the `*:extkeys` wildcard. Entrypoint suite: 105 pass, 2 pre-existing failures (codex session-storage env leakage on `main`, unrelated).

Note: entrypoint ships in the base image, so this needs an image rebuild to take effect.