### PR TITLE
fix: tmux extended-keys-format csi-u for Pi modified keys

### DIFF
--- a/static/build/docker-entrypoint
+++ b/static/build/docker-entrypoint
@@ -78,7 +78,10 @@ set -g default-terminal "xterm-256color"
 # them (Kitty keyboard protocol). The "*" pattern advertises extkeys for every
 # outer terminal that supports it, not just xterm-named ones, so Shift+Enter
 # reaches agents like Pi regardless of TERM. (Ctrl+J is the universal fallback.)
+# extended-keys-format must be csi-u (fixterms): tmux's default "xterm" encoding
+# is undecodable by Pi and other Kitty-protocol agents, so modified Enter is lost.
 set -g extended-keys on
+set -g extended-keys-format csi-u
 set -as terminal-features "*:extkeys"
 set -g status-position top
 set -g status-style "bg=colour236,fg=colour255"

--- a/static/build/docker-entrypoint_test.sh
+++ b/static/build/docker-entrypoint_test.sh
@@ -744,6 +744,7 @@ test_write_tmux_conf_scroll_settings() {
     assert_contains "write_tmux_conf sets large history" "$output" 'set -g history-limit 100000'
     assert_contains "write_tmux_conf enables extended-keys" "$output" 'set -g extended-keys on'
     assert_contains "write_tmux_conf advertises extkeys for all terminals" "$output" 'terminal-features "*:extkeys"'
+    assert_contains "write_tmux_conf uses csi-u extended-keys format" "$output" 'set -g extended-keys-format csi-u'
     assert_contains "write_tmux_conf shows workspace shortcut" "$output" 'C-M-p: workspaces'
     assert_contains "write_tmux_conf shows session shortcut" "$output" 'C-M-s: sessions'
 }


### PR DESCRIPTION
Pi warns: `tmux extended-keys-format is xterm. Pi works best with csi-u`. ExitBox's generated tmux config enabled `extended-keys on` and advertised the `extkeys` feature, but never set `extended-keys-format`, so tmux used its default `xterm` encoding for modified keys. Pi (and other Kitty-protocol agents) can't decode that encoding, so Shift+Enter was lost — while agents that tolerate the xterm encoding kept working (explains "all other agents fine, just not Pi").

## Fix
Add `set -g extended-keys-format csi-u` to the generated tmux config (the fixterms/CSI-u encoding Pi expects). Pairs with the existing `extended-keys on` + `terminal-features "*:extkeys"`.

## Tests
Added a `write_tmux_conf` assertion for `extended-keys-format csi-u`. Entrypoint suite: 106 pass, 2 pre-existing failures (codex session-storage env leakage on `main`, unrelated).

Note: entrypoint ships in the base image — needs an image rebuild to take effect. If `exitbox` is run from inside another (host) tmux, that outer tmux must carry the same `extended-keys on` / `extended-keys-format csi-u` / `terminal-features *:extkeys` settings, or it strips modified keys before they reach the container.