### PR TITLE
fix: tmux-256color default-terminal for extended keys (Pi Shift+Enter)

### DIFF
--- a/static/build/docker-entrypoint
+++ b/static/build/docker-entrypoint
@@ -65,15 +65,25 @@ update_tmux_status() {
 
 write_tmux_conf() {
     local conf="/tmp/exitbox-tmux.conf"
-    local display ws_name ver session_name
+    local display ws_name ver session_name default_term
     display="$(agent_display_name "$AGENT")"
     ws_name="${EXITBOX_WORKSPACE_NAME:-default}"
     ver="${EXITBOX_VERSION:-dev}"
     session_name="${EXITBOX_SESSION_NAME:-default}"
 
+    # Present tmux-256color to inner apps: unlike xterm-256color, its terminfo
+    # declares the extended-key capabilities tmux needs to forward modified keys
+    # (Shift+Enter, etc.) to Kitty-protocol TUIs like Pi. Fall back to
+    # xterm-256color if that terminfo entry isn't installed.
+    if infocmp tmux-256color >/dev/null 2>&1; then
+        default_term="tmux-256color"
+    else
+        default_term="xterm-256color"
+    fi
+
     cat > "$conf" <<TMUXEOF
 # ExitBox tmux configuration
-set -g default-terminal "xterm-256color"
+set -g default-terminal "${default_term}"
 # Forward modified keys (e.g. Shift+Enter / Alt+Enter) to agent TUIs that request
 # them (Kitty keyboard protocol). The "*" pattern advertises extkeys for every
 # outer terminal that supports it, not just xterm-named ones, so Shift+Enter

--- a/static/build/docker-entrypoint_test.sh
+++ b/static/build/docker-entrypoint_test.sh
@@ -750,6 +750,36 @@ test_write_tmux_conf_scroll_settings() {
 }
 
 # ============================================================================
+# Test: write_tmux_conf default-terminal prefers tmux-256color (extended keys)
+# ============================================================================
+test_write_tmux_conf_default_terminal() {
+    # When tmux-256color terminfo is available, it must be the default-terminal
+    # (its terminfo declares the extended-key capabilities Pi needs).
+    local with_tmux
+    with_tmux="$(
+        AGENT="pi"; EXITBOX_WORKSPACE_NAME="default"; EXITBOX_VERSION="test"
+        unset EXITBOX_KEYBINDINGS
+        eval "$PARSE_KB_FUNC"; parse_keybindings
+        eval "$DISPLAY_FUNC"; eval "$TMUX_CONF_FUNC"
+        infocmp() { return 0; }
+        cat "$(write_tmux_conf)"
+    )" 2>/dev/null
+    assert_contains "default-terminal prefers tmux-256color" "$with_tmux" 'set -g default-terminal "tmux-256color"'
+
+    # When it is NOT available, fall back to xterm-256color (no breakage).
+    local without_tmux
+    without_tmux="$(
+        AGENT="pi"; EXITBOX_WORKSPACE_NAME="default"; EXITBOX_VERSION="test"
+        unset EXITBOX_KEYBINDINGS
+        eval "$PARSE_KB_FUNC"; parse_keybindings
+        eval "$DISPLAY_FUNC"; eval "$TMUX_CONF_FUNC"
+        infocmp() { return 1; }
+        cat "$(write_tmux_conf)"
+    )" 2>/dev/null
+    assert_contains "default-terminal falls back to xterm-256color" "$without_tmux" 'set -g default-terminal "xterm-256color"'
+}
+
+# ============================================================================
 # Test: parse_keybindings defaults (no env var)
 # ============================================================================
 test_parse_keybindings_default() {
@@ -847,6 +877,7 @@ test_should_exec_raw_detects_auth_keywords
 test_run_raw_command_prefixes_agent
 test_build_agent_loop_command_passthrough
 test_write_tmux_conf_scroll_settings
+test_write_tmux_conf_default_terminal
 test_parse_keybindings_default
 test_parse_keybindings_custom
 test_parse_keybindings_partial


### PR DESCRIPTION
Pi's modified keys (Shift+Enter, Ctrl+J) do nothing inside ExitBox's tmux, even with `extended-keys on` + `extended-keys-format csi-u` + `terminal-features *:extkeys` (all already on main). They DO work with `--no-tmux`, but tmux is required for ExitBox's status bar / workspace switcher / session resume.

## Cause

The generated tmux config set `default-terminal "xterm-256color"`. The `xterm-256color` terminfo does not declare the extended-key capabilities tmux relies on to expose modified keys to inner programs; `tmux-256color` (the value the tmux project recommends) does. With xterm-256color, Pi's Kitty/extended-keys negotiation through tmux doesn't yield modified keys.

## Fix

Set `default-terminal "tmux-256color"` (terminfo ships in Alpine's `ncurses-terminfo-base`, already in the base image), with a safe `infocmp` fallback to `xterm-256color` if the entry is ever missing.

## Tests

New `test_write_tmux_conf_default_terminal`: stubs `infocmp` to assert tmux-256color is chosen when available and xterm-256color when not. Entrypoint suite: 108 pass, 2 pre-existing failures (codex session-storage env leakage, unrelated).

Note: entrypoint ships in the base image — needs an image rebuild to take effect.