### PR TITLE
fix: link ExitBox-managed skills into Pi

### DIFF
--- a/static/build/docker-entrypoint
+++ b/static/build/docker-entrypoint
@@ -520,6 +520,14 @@ link_skills() {
             [[ -d "$real_dir" ]] && _link_skills_into "$real_dir/skills"
             _link_skills_into "$HOME/.agents/skills"
             ;;
+        pi)
+            # Pi discovers skills (dirs with SKILL.md) in ~/.pi/agent/skills and
+            # ~/.agents/skills. ~/.pi is symlinked to the persistent workspace dir.
+            local real_dir
+            real_dir="$(readlink -f "$HOME/.pi")"
+            [[ -d "$real_dir" ]] && _link_skills_into "$real_dir/agent/skills"
+            _link_skills_into "$HOME/.agents/skills"
+            ;;
     esac
 }
 

--- a/static/build/docker-entrypoint_test.sh
+++ b/static/build/docker-entrypoint_test.sh
@@ -1673,6 +1673,30 @@ test_agent_display_name_new_agents
 test_workspace_links_new_agents
 
 # ============================================================================
+# Test: link_skills wires ExitBox-managed skills into Pi's skills dir
+# ============================================================================
+test_link_skills_pi() {
+    local base home result
+    base="$(mktemp -d "$TEST_TMPDIR/skillws.XXXXXX")"
+    home="$(mktemp -d "$TEST_TMPDIR/skillhome.XXXXXX")"
+    mkdir -p "$base/default/skills/my-skill"
+    printf -- '---\nname: my-skill\n---\n' > "$base/default/skills/my-skill/SKILL.md"
+    mkdir -p "$home/.pi/agent"
+    result="$(
+        export GLOBAL_WORKSPACE_ROOT="$base"
+        export HOME="$home"
+        export AGENT="pi"
+        export EXITBOX_WORKSPACE_NAME="default"
+        eval "$(extract_func link_skills)"
+        link_skills
+        [[ -L "$home/.pi/agent/skills/my-skill" ]] && echo "LINKED"
+    )" 2>/dev/null
+    assert_contains "link_skills links ExitBox skills into Pi ~/.pi/agent/skills" "$result" "LINKED"
+}
+
+test_link_skills_pi
+
+# ============================================================================
 # Results
 # ============================================================================
 


### PR DESCRIPTION
ExitBox-managed skills (`~/.exitbox-config/profiles/global/<ws>/skills/*`) weren't appearing in Pi. The entrypoint's `link_skills` only had cases for claude/codex/opencode — Pi (like qwen/cursor/kimi) had none, so skills were never linked into Pi's skills directory.

## Fix

Add a `pi)` case to `link_skills` that symlinks each managed skill into `~/.pi/agent/skills/` (and `~/.agents/skills/`), Pi's documented global skill locations. Pi discovers directories containing `SKILL.md` there — the same format ExitBox stores skills in. `~/.pi` is already symlinked to the persistent workspace dir, so `readlink -f` resolves it.

## Tests

New `test_link_skills_pi`: seeds a workspace skill, runs `link_skills` with `AGENT=pi`, asserts the symlink lands in `~/.pi/agent/skills/`. Entrypoint suite: 109 pass, 2 pre-existing failures (codex session-storage env leakage, unrelated).

Note: entrypoint ships in the base image — needs an image rebuild to take effect.