### PR TITLE
fix: install codex-code-mode-host alongside codex (code review)

### DIFF
--- a/internal/agents/codex/codex.go
+++ b/internal/agents/codex/codex.go
@@ -55,6 +55,20 @@ func (c *Codex) BinaryName() string {
 	}
 }
 
+// CodeModeHostBinaryName returns the release tarball for codex-code-mode-host, the
+// sibling binary recent Codex versions spawn for code review / "code mode". It ships
+// as a separate release asset and must be installed alongside the codex binary.
+func (c *Codex) CodeModeHostBinaryName() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz"
+	case "arm64":
+		return "codex-code-mode-host-aarch64-unknown-linux-musl.tar.gz"
+	default:
+		return ""
+	}
+}
+
 func (c *Codex) HostConfigPaths() []string {
 	home := os.Getenv("HOME")
 	return []string{

--- a/internal/agents/codex/codex_test.go
+++ b/internal/agents/codex/codex_test.go
@@ -47,6 +47,19 @@ func TestCodexAgent(t *testing.T) {
 		}
 	}
 
+	// CodeModeHostBinaryName
+	hbn := c.CodeModeHostBinaryName()
+	switch runtime.GOARCH {
+	case "amd64":
+		if hbn != "codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz" {
+			t.Errorf("CodeModeHostBinaryName() = %q on amd64", hbn)
+		}
+	case "arm64":
+		if hbn != "codex-code-mode-host-aarch64-unknown-linux-musl.tar.gz" {
+			t.Errorf("CodeModeHostBinaryName() = %q on arm64", hbn)
+		}
+	}
+
 	// HostConfigPaths
 	paths := c.HostConfigPaths()
 	if len(paths) != 2 {
@@ -72,6 +85,12 @@ func TestCodexAgent(t *testing.T) {
 	}
 	if !strings.Contains(df, "apk add --no-cache bubblewrap") {
 		t.Error("GetDockerfileInstall() should install bubblewrap")
+	}
+	if !strings.Contains(df, "$HOME/.local/bin/codex-code-mode-host") {
+		t.Error("GetDockerfileInstall() should install codex-code-mode-host alongside codex")
+	}
+	if !strings.Contains(df, "CODEX_CODE_MODE_HOST_CHECKSUM") {
+		t.Error("GetDockerfileInstall() should verify the codex-code-mode-host checksum")
 	}
 
 	// GetFullDockerfile

--- a/internal/agents/codex/docker.go
+++ b/internal/agents/codex/docker.go
@@ -30,20 +30,33 @@ func (c *Codex) GetDockerfileInstall(buildCtx string) (string, error) {
 	if binaryName == "" {
 		return "", fmt.Errorf("unsupported architecture for Codex")
 	}
+	hostBinaryName := c.CodeModeHostBinaryName()
+	if hostBinaryName == "" {
+		return "", fmt.Errorf("unsupported architecture for Codex")
+	}
 	binaryInside := strings.TrimSuffix(binaryName, ".tar.gz")
+	hostBinaryInside := strings.TrimSuffix(hostBinaryName, ".tar.gz")
 
-	return fmt.Sprintf(`# Install Codex runtime dependencies and binary with SHA-256 verification
+	return fmt.Sprintf(`# Install Codex runtime dependencies and binaries with SHA-256 verification.
+# codex-code-mode-host is a sibling binary recent Codex versions spawn for code
+# review / "code mode"; it ships as a separate release asset and must sit next to
+# the codex binary or the feature fails with "codex-code-mode-host is missing".
 RUN apk add --no-cache bubblewrap
 ARG CODEX_VERSION
 ARG CODEX_CHECKSUM
+ARG CODEX_CODE_MODE_HOST_CHECKSUM
 COPY %s /tmp/codex.tar.gz
+COPY %s /tmp/codex-code-mode-host.tar.gz
 RUN echo "${CODEX_CHECKSUM}  /tmp/codex.tar.gz" | sha256sum -c - && \
+    echo "${CODEX_CODE_MODE_HOST_CHECKSUM}  /tmp/codex-code-mode-host.tar.gz" | sha256sum -c - && \
     mkdir -p $HOME/.local/bin && \
     tar -xzf /tmp/codex.tar.gz -C /tmp && \
+    tar -xzf /tmp/codex-code-mode-host.tar.gz -C /tmp && \
     mv /tmp/%s $HOME/.local/bin/codex && \
-    chmod +x $HOME/.local/bin/codex && \
-    rm -f /tmp/codex.tar.gz && \
-    $HOME/.local/bin/codex --version`, binaryName, binaryInside), nil
+    mv /tmp/%s $HOME/.local/bin/codex-code-mode-host && \
+    chmod +x $HOME/.local/bin/codex $HOME/.local/bin/codex-code-mode-host && \
+    rm -f /tmp/codex.tar.gz /tmp/codex-code-mode-host.tar.gz && \
+    $HOME/.local/bin/codex --version`, binaryName, hostBinaryName, binaryInside, hostBinaryInside), nil
 }
 
 func (c *Codex) GetFullDockerfile(version string) (string, error) {
@@ -72,6 +85,10 @@ func (c *Codex) PrepareBuild(in agent.PrepareBuildInput) error {
 	if binaryName == "" {
 		return fmt.Errorf("unsupported architecture for Codex")
 	}
+	hostBinaryName := c.CodeModeHostBinaryName()
+	if hostBinaryName == "" {
+		return fmt.Errorf("unsupported architecture for Codex")
+	}
 	if in.Download == nil || in.FileSHA256 == nil {
 		return fmt.Errorf("PrepareBuildInput.Download and FileSHA256 are required for Codex")
 	}
@@ -87,7 +104,22 @@ func (c *Codex) PrepareBuild(in agent.PrepareBuildInput) error {
 	if in.Logf != nil {
 		in.Logf("Codex SHA-256: %s", checksum)
 	}
-	df := fmt.Sprintf("FROM exitbox-base\n\nARG CODEX_VERSION=%s\nARG CODEX_CHECKSUM=%s\n", version, checksum)
+
+	// codex-code-mode-host is a separate release asset installed alongside codex.
+	hostURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", codexGitHubRepo, version, hostBinaryName)
+	if in.Logf != nil {
+		in.Logf("Downloading codex-code-mode-host %s...", version)
+	}
+	hostDlPath := filepath.Join(in.BuildDir, hostBinaryName)
+	if err := in.Download(in.Ctx, hostURL, hostDlPath); err != nil {
+		return fmt.Errorf("failed to download codex-code-mode-host: %w", err)
+	}
+	hostChecksum := in.FileSHA256(hostDlPath)
+	if in.Logf != nil {
+		in.Logf("codex-code-mode-host SHA-256: %s", hostChecksum)
+	}
+
+	df := fmt.Sprintf("FROM exitbox-base\n\nARG CODEX_VERSION=%s\nARG CODEX_CHECKSUM=%s\nARG CODEX_CODE_MODE_HOST_CHECKSUM=%s\n", version, checksum, hostChecksum)
 	install, err := c.GetDockerfileInstall(in.BuildDir)
 	if err != nil {
 		return fmt.Errorf("failed to get Codex install instructions: %w", err)


### PR DESCRIPTION
Recent Codex versions spawn a sibling binary `codex-code-mode-host` for the new code-review / "code mode" feature. It ships as a **separate release asset**, but ExitBox only downloaded the main `codex` tarball — so code review failed with:

> Unable to review the changes because the repository inspection tool failed to start (codex-code-mode-host is missing).

## Fix

- `CodeModeHostBinaryName()` returns the `codex-code-mode-host-<arch>-unknown-linux-musl.tar.gz` asset.
- `PrepareBuild` now downloads it too, computes its SHA-256, and passes it as `CODEX_CODE_MODE_HOST_CHECKSUM`.
- `GetDockerfileInstall` COPYs + checksum-verifies + extracts it to `$HOME/.local/bin/codex-code-mode-host`, next to the `codex` binary (verified the tarball extracts to `codex-code-mode-host-<arch>-unknown-linux-musl`, same convention as codex).

Codex looks for the host binary beside itself / on PATH, and `$HOME/.local/bin` is both — so code review works after a rebuild.

## Tests

`codex_test.go`: assert `CodeModeHostBinaryName()` per arch, and that `GetDockerfileInstall` installs `codex-code-mode-host` + verifies its checksum. `go build`, `go test ./...`, `go vet`, `golangci-lint` green.

Caveat: pinning `agents.codex.version` to a very old release (before the code-mode-host asset existed) will now fail the download; use latest (the default). Needs an image rebuild (`exitbox run codex --update`).